### PR TITLE
Add DOM inspection and image download actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Looking for a powerful AI web agent without the $200/month price tag of OpenAI O
 - **Follow-up Questions**: Ask contextual follow-up questions about completed tasks
 - **Conversation History**: Easily access and manage your AI agent interaction history
 - **Multiple LLM Support**: Connect your preferred LLM providers and assign different models to different agents
+- **DOM Inspection**: Retrieve DOM details by selector and extract image URLs
+- **Image Download**: Save images from the current page to your computer
 
 
 ## 🚀 Quick Start

--- a/chrome-extension/src/background/agent/actions/schemas.ts
+++ b/chrome-extension/src/background/agent/actions/schemas.ts
@@ -175,3 +175,31 @@ export const waitActionSchema: ActionSchema = {
     seconds: z.number().nullable().optional(),
   }),
 };
+
+export const getDomInfoActionSchema: ActionSchema = {
+  name: 'get_dom_info',
+  description: 'Get DOM outer HTML for the element specified by CSS selector',
+  schema: z.object({
+    intent: z.string().optional(),
+    selector: z.string(),
+  }),
+};
+
+export const extractImgSrcActionSchema: ActionSchema = {
+  name: 'extract_img_src',
+  description: 'Extract image src URLs from a DOM string',
+  schema: z.object({
+    intent: z.string().optional(),
+    dom: z.string(),
+  }),
+};
+
+export const downloadImageActionSchema: ActionSchema = {
+  name: 'download_image',
+  description: 'Download image from URL to local storage',
+  schema: z.object({
+    intent: z.string().optional(),
+    url: z.string(),
+    filename: z.string().optional(),
+  }),
+};

--- a/chrome-extension/src/background/browser/page.ts
+++ b/chrome-extension/src/background/browser/page.ts
@@ -1049,6 +1049,37 @@ export default class Page {
     return selectorMap.get(index) || null;
   }
 
+  async getDomInfo(selector: string): Promise<string> {
+    if (!this._puppeteerPage) {
+      throw new Error('Puppeteer page is not connected');
+    }
+
+    try {
+      const html = await this._puppeteerPage.$eval(selector, el => el.outerHTML);
+      return html as string;
+    } catch (error) {
+      throw new Error(`Failed to get DOM info: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  async extractImgSrcFromDom(dom: string): Promise<string[]> {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(dom, 'text/html');
+    const images = Array.from(doc.querySelectorAll('img')) as HTMLImageElement[];
+    return images.map(img => img.src).filter(src => src);
+  }
+
+  async downloadImage(url: string, filename?: string): Promise<string> {
+    try {
+      const options: chrome.downloads.DownloadOptions = { url };
+      if (filename) options.filename = filename;
+      await chrome.downloads.download(options);
+      return `Downloaded ${url}`;
+    } catch (error) {
+      throw new Error(`Failed to download image: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
   isFileUploader(elementNode: DOMElementNode, maxDepth = 3, currentDepth = 0): boolean {
     if (currentDepth > maxDepth) {
       return false;


### PR DESCRIPTION
## Summary
- extend action schemas with new DOM and image actions
- implement DOM info retrieval and image extraction/downloading in Page
- expose new actions in the builder
- document DOM inspection and image download features

## Testing
- `npm run lint` *(fails: turbo not found)*