### PR TITLE
Add DOM tools to action schemas and prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Looking for a powerful AI web agent without the $200/month price tag of OpenAI O
 - **Follow-up Questions**: Ask contextual follow-up questions about completed tasks
 - **Conversation History**: Easily access and manage your AI agent interaction history
 - **Multiple LLM Support**: Connect your preferred LLM providers and assign different models to different agents
+- **DOM Inspection**: Retrieve DOM details by selector and extract image URLs
+- **Image Download**: Save images from the current page to your computer
 
 
 ## 🚀 Quick Start

--- a/chrome-extension/src/background/agent/actions/json_gemini.ts
+++ b/chrome-extension/src/background/agent/actions/json_gemini.ts
@@ -293,6 +293,55 @@ export const geminiNavigatorOutputSchema = {
             },
             required: ['intent', 'index', 'text'],
           },
+          get_dom_info: {
+            type: 'object',
+            description: 'Get DOM outer HTML for the element specified by CSS selector',
+            nullable: true,
+            properties: {
+              intent: {
+                type: 'string',
+                description: 'purpose of this action',
+              },
+              selector: {
+                type: 'string',
+              },
+            },
+            required: ['intent', 'selector'],
+          },
+          extract_img_src: {
+            type: 'object',
+            description: 'Extract image src URLs from a DOM string',
+            nullable: true,
+            properties: {
+              intent: {
+                type: 'string',
+                description: 'purpose of this action',
+              },
+              dom: {
+                type: 'string',
+              },
+            },
+            required: ['intent', 'dom'],
+          },
+          download_image: {
+            type: 'object',
+            description: 'Download image from URL to local storage',
+            nullable: true,
+            properties: {
+              intent: {
+                type: 'string',
+                description: 'purpose of this action',
+              },
+              url: {
+                type: 'string',
+              },
+              filename: {
+                type: 'string',
+                nullable: true,
+              },
+            },
+            required: ['intent', 'url'],
+          },
         },
       },
     },

--- a/chrome-extension/src/background/agent/actions/json_schema.ts
+++ b/chrome-extension/src/background/agent/actions/json_schema.ts
@@ -350,6 +350,65 @@ export const jsonNavigatorOutputSchema = {
             type: 'object',
             nullable: true,
           },
+          get_dom_info: {
+            description: 'Get DOM outer HTML for the element specified by CSS selector',
+            properties: {
+              intent: {
+                title: 'Intent',
+                type: 'string',
+                description: 'purpose of this action',
+              },
+              selector: {
+                title: 'Selector',
+                type: 'string',
+              },
+            },
+            required: ['intent', 'selector'],
+            title: 'get_dom_info_parameters',
+            type: 'object',
+            nullable: true,
+          },
+          extract_img_src: {
+            description: 'Extract image src URLs from a DOM string',
+            properties: {
+              intent: {
+                title: 'Intent',
+                type: 'string',
+                description: 'purpose of this action',
+              },
+              dom: {
+                title: 'Dom',
+                type: 'string',
+              },
+            },
+            required: ['intent', 'dom'],
+            title: 'extract_img_src_parameters',
+            type: 'object',
+            nullable: true,
+          },
+          download_image: {
+            description: 'Download image from URL to local storage',
+            properties: {
+              intent: {
+                title: 'Intent',
+                type: 'string',
+                description: 'purpose of this action',
+              },
+              url: {
+                title: 'Url',
+                type: 'string',
+              },
+              filename: {
+                title: 'Filename',
+                type: 'string',
+                nullable: true,
+              },
+            },
+            required: ['intent', 'url'],
+            title: 'download_image_parameters',
+            type: 'object',
+            nullable: true,
+          },
         },
         title: 'ActionModel',
         type: 'object',

--- a/chrome-extension/src/background/agent/actions/schemas.ts
+++ b/chrome-extension/src/background/agent/actions/schemas.ts
@@ -175,3 +175,31 @@ export const waitActionSchema: ActionSchema = {
     seconds: z.number().nullable().optional(),
   }),
 };
+
+export const getDomInfoActionSchema: ActionSchema = {
+  name: 'get_dom_info',
+  description: 'Get DOM outer HTML for the element specified by CSS selector',
+  schema: z.object({
+    intent: z.string().optional(),
+    selector: z.string(),
+  }),
+};
+
+export const extractImgSrcActionSchema: ActionSchema = {
+  name: 'extract_img_src',
+  description: 'Extract image src URLs from a DOM string',
+  schema: z.object({
+    intent: z.string().optional(),
+    dom: z.string(),
+  }),
+};
+
+export const downloadImageActionSchema: ActionSchema = {
+  name: 'download_image',
+  description: 'Download image from URL to local storage',
+  schema: z.object({
+    intent: z.string().optional(),
+    url: z.string(),
+    filename: z.string().optional(),
+  }),
+};

--- a/chrome-extension/src/background/agent/prompts/templates/navigator.ts
+++ b/chrome-extension/src/background/agent/prompts/templates/navigator.ts
@@ -122,5 +122,11 @@ Common action sequences:
 - Plan is a json string wrapped by the <plan> tag
 - If a plan is provided, follow the instructions in the next_steps exactly first
 - If no plan is provided, just continue with the task
+
+12. DOM & Images:
+
+- Use `get_dom_info` to fetch the outer HTML for a CSS selector when you need details that are not visible.
+- Use `extract_img_src` on that HTML to list all image URLs.
+- Use `download_image` with an image URL to save it locally.
 </system_instructions>
 `;

--- a/chrome-extension/src/background/browser/page.ts
+++ b/chrome-extension/src/background/browser/page.ts
@@ -1049,6 +1049,37 @@ export default class Page {
     return selectorMap.get(index) || null;
   }
 
+  async getDomInfo(selector: string): Promise<string> {
+    if (!this._puppeteerPage) {
+      throw new Error('Puppeteer page is not connected');
+    }
+
+    try {
+      const html = await this._puppeteerPage.$eval(selector, el => el.outerHTML);
+      return html as string;
+    } catch (error) {
+      throw new Error(`Failed to get DOM info: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  async extractImgSrcFromDom(dom: string): Promise<string[]> {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(dom, 'text/html');
+    const images = Array.from(doc.querySelectorAll('img')) as HTMLImageElement[];
+    return images.map(img => img.src).filter(src => src);
+  }
+
+  async downloadImage(url: string, filename?: string): Promise<string> {
+    try {
+      const options: chrome.downloads.DownloadOptions = { url };
+      if (filename) options.filename = filename;
+      await chrome.downloads.download(options);
+      return `Downloaded ${url}`;
+    } catch (error) {
+      throw new Error(`Failed to download image: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
   isFileUploader(elementNode: DOMElementNode, maxDepth = 3, currentDepth = 0): boolean {
     if (currentDepth > maxDepth) {
       return false;

--- a/packages/schema-utils/lib/json_schema.ts
+++ b/packages/schema-utils/lib/json_schema.ts
@@ -202,6 +202,39 @@ export const jsonNavigatorOutputSchema = {
           description:
             'Select dropdown option for interactive element index by the text of the option you want to select',
         },
+        get_dom_info: {
+          anyOf: [
+            {
+              $ref: '#/$defs/get_dom_info_parameters',
+            },
+            {
+              type: 'null',
+            },
+          ],
+          description: 'Get DOM outer HTML for the element specified by CSS selector',
+        },
+        extract_img_src: {
+          anyOf: [
+            {
+              $ref: '#/$defs/extract_img_src_parameters',
+            },
+            {
+              type: 'null',
+            },
+          ],
+          description: 'Extract image src URLs from a DOM string',
+        },
+        download_image: {
+          anyOf: [
+            {
+              $ref: '#/$defs/download_image_parameters',
+            },
+            {
+              type: 'null',
+            },
+          ],
+          description: 'Download image from URL to local storage',
+        },
       },
       title: 'ActionModel',
       type: 'object',
@@ -496,6 +529,59 @@ export const jsonNavigatorOutputSchema = {
       },
       required: ['intent', 'index', 'text'],
       title: 'select_dropdown_option_parameters',
+      type: 'object',
+    },
+    get_dom_info_parameters: {
+      properties: {
+        intent: {
+          title: 'Intent',
+          type: 'string',
+          description: 'purpose of this action',
+        },
+        selector: {
+          title: 'Selector',
+          type: 'string',
+        },
+      },
+      required: ['intent', 'selector'],
+      title: 'get_dom_info_parameters',
+      type: 'object',
+    },
+    extract_img_src_parameters: {
+      properties: {
+        intent: {
+          title: 'Intent',
+          type: 'string',
+          description: 'purpose of this action',
+        },
+        dom: {
+          title: 'Dom',
+          type: 'string',
+        },
+      },
+      required: ['intent', 'dom'],
+      title: 'extract_img_src_parameters',
+      type: 'object',
+    },
+    download_image_parameters: {
+      properties: {
+        intent: {
+          title: 'Intent',
+          type: 'string',
+          description: 'purpose of this action',
+        },
+        url: {
+          title: 'Url',
+          type: 'string',
+        },
+        filename: {
+          title: 'Filename',
+          type: 'string',
+          nullable: true,
+        },
+      },
+      required: ['intent', 'url'],
+      title: 'download_image_parameters',
       type: 'object',
     },
     WaitAction: {


### PR DESCRIPTION
## Summary
- add DOM and image download instructions to the navigator prompt
- extend navigator JSON schemas with get_dom_info, extract_img_src and download_image
- include new action parameter definitions in shared schema

## Testing
- `npm run lint` *(fails: turbo not found)*